### PR TITLE
Add namespace feature SocketIOConnection.

### DIFF
--- a/SocketIOSharp/Common/Abstract/Connection/SocketIOConnection.Event.cs
+++ b/SocketIOSharp/Common/Abstract/Connection/SocketIOConnection.Event.cs
@@ -88,14 +88,14 @@ namespace SocketIOSharp.Common.Abstract.Connection
                 {
                     JToken Event = Temp.Dequeue();
                     JToken[] Data = Temp.ToArray();
-
-                    CallEventHandler(Event, Data);
-                    CallAckEventHandler(Event, Packet.ID, Data);
+                    Temp.Enqueue(Packet.Namespace);
+                    CallEventHandler(Event, Temp.ToArray());
+                    CallAckEventHandler(Event, Packet.ID, Packet.Namespace, Data);
                 }
             }
         }
 
-        private void CallAckEventHandler(JToken Event, int PacketID, params JToken[] Data)
+        private void CallAckEventHandler(JToken Event, int PacketID, string ns, params JToken[] Data)
         {
             if (Event != null)
             {
@@ -105,7 +105,7 @@ namespace SocketIOSharp.Common.Abstract.Connection
                 {
                     Callback = (AckData) =>
                     {
-                        Emit(SocketIOPacket.CreateAckPacket(new JArray(AckData), PacketID));
+                        Emit(SocketIOPacket.CreateAckPacket(new JArray(AckData), PacketID, ns));
                     };
                 }
 

--- a/SocketIOSharp/Common/Abstract/Connection/SocketIOConnection.cs
+++ b/SocketIOSharp/Common/Abstract/Connection/SocketIOConnection.cs
@@ -28,7 +28,7 @@ namespace SocketIOSharp.Common.Abstract.Connection
             switch (Packet.Type)
             {
                 case SocketIOPacketType.CONNECT:
-                    OnConnect();
+                    OnConnect(Packet);
                     break;
 
                 case SocketIOPacketType.DISCONNECT:
@@ -61,9 +61,11 @@ namespace SocketIOSharp.Common.Abstract.Connection
             }
         }
 
-        private void OnConnect()
+        private void OnConnect(SocketIOPacket Packet)
         {
-            CallEventHandler(SocketIOEvent.CONNECTION);
+            CallEventHandler(SocketIOEvent.CONNECTION, Packet.Namespace);
+            
+            Emit(SocketIOPacket.CreateConnectionPacket(Packet.Namespace));
         }
 
         protected void OnDisconnect(Exception Exception)
@@ -89,7 +91,7 @@ namespace SocketIOSharp.Common.Abstract.Connection
 
         private void OnError(SocketIOPacket Packet)
         {
-            CallEventHandler(SocketIOEvent.ERROR, Packet?.JsonData?.ToString() ?? string.Empty);
+            CallEventHandler(SocketIOEvent.ERROR, Packet.Namespace, Packet?.JsonData?.ToString() ?? string.Empty);
         }
 
         private void OnBinaryEvent(SocketIOPacket Packet)

--- a/SocketIOSharp/Common/Abstract/SocketIO.Emit.cs
+++ b/SocketIOSharp/Common/Abstract/SocketIO.Emit.cs
@@ -25,17 +25,17 @@ namespace SocketIOSharp.Common.Abstract
             return Result;
         }
 
-        public TChildClass Emit(JToken Event, Action<JToken[]> Callback = null)
+        public TChildClass Emit(JToken Event, string ns = "/", Action<JToken[]> Callback = null)
         {
-            return Emit(Event, Arguments(Callback));
+            return Emit(Event, ns, Arguments(Callback));
         }
 
-        public TChildClass Emit(JToken Event, JToken Data, Action<JToken[]> Callback = null)
+        public TChildClass Emit(JToken Event, JToken Data,  string ns = "/", Action<JToken[]> Callback = null)
         {
-            return Emit(Event, Arguments(Data, Callback));
+            return Emit(Event, ns, Arguments(Data, Callback));
         }
 
-        public TChildClass Emit(JToken Event, params object[] Arguments)
+        private TChildClass Emit(JToken Event, string ns, params object[] Arguments)
         {
             if (Event != null)
             {
@@ -61,7 +61,7 @@ namespace SocketIOSharp.Common.Abstract
                     JsonArray.Add(Data);
                 }
 
-                Emit(SocketIOPacket.CreateEventPacket(JsonArray, AckManager.CreateAck(Callback)));
+                Emit(SocketIOPacket.CreateEventPacket(JsonArray, AckManager.CreateAck(Callback), ns));
             }
 
             return this as TChildClass;

--- a/SocketIOSharp/Common/Packet/SocketIOPacket.Static/SocketIOPacket.Decoder.cs
+++ b/SocketIOSharp/Common/Packet/SocketIOPacket.Static/SocketIOPacket.Decoder.cs
@@ -81,28 +81,31 @@ namespace SocketIOSharp.Common.Packet
                     Packet.Namespace = "/";
                 }
 
-                char Next = Data[Offset + 1];
-
-                if (!char.IsWhiteSpace(Next) && char.IsNumber(Next))
+                if (Offset < Data.Length - 1)
                 {
-                    StringBuilder Builder = new StringBuilder();
+                    char Next = Data[Offset + 1];
 
-                    while (Offset < Data.Length - 1)
+                    if (!char.IsWhiteSpace(Next) && char.IsNumber(Next))
                     {
-                        char c = Data[++Offset];
+                        StringBuilder Builder = new StringBuilder();
 
-                        if (char.IsNumber(c))
+                        while (Offset < Data.Length - 1)
                         {
-                            Builder.Append(c);
+                            char c = Data[++Offset];
+
+                            if (char.IsNumber(c))
+                            {
+                                Builder.Append(c);
+                            }
+                            else
+                            {
+                                --Offset;
+                                break;
+                            }
                         }
-                        else
-                        {
-                            --Offset;
-                            break;
-                        }
+
+                        Packet.ID = int.Parse(Builder.ToString());
                     }
-
-                    Packet.ID = int.Parse(Builder.ToString());
                 }
 
                 if (++Offset < Data.Length - 1)

--- a/SocketIOSharp/Common/Packet/SocketIOPacket.Static/SocketIOPacket.Factory.cs
+++ b/SocketIOSharp/Common/Packet/SocketIOPacket.Static/SocketIOPacket.Factory.cs
@@ -5,18 +5,19 @@ namespace SocketIOSharp.Common.Packet
 {
     partial class SocketIOPacket
     {
-        internal static SocketIOPacket CreateConnectionPacket()
+        internal static SocketIOPacket CreateConnectionPacket(string ns = "/")
         {
             return new SocketIOPacket()
             {
                 Type = SocketIOPacketType.CONNECT,
-                IsJson = true
+                IsJson = true,
+                Namespace = ns
             };
         }
 
-        internal static SocketIOPacket CreateEventPacket(JArray JsonArray, SocketIOAck Ack)
+        internal static SocketIOPacket CreateEventPacket(JArray JsonArray, SocketIOAck Ack, string ns)
         {
-            SocketIOPacket Packet = CreateMessagePacket(JsonArray, Ack);
+            SocketIOPacket Packet = CreateMessagePacket(JsonArray, Ack, ns);
 
             if (Packet.IsJson)
             {
@@ -31,11 +32,11 @@ namespace SocketIOSharp.Common.Packet
             return Packet;
         }
 
-        internal static SocketIOPacket CreateAckPacket(JArray JsonArray, int PacketID)
+        internal static SocketIOPacket CreateAckPacket(JArray JsonArray, int PacketID, string ns = "/")
         {
             if (PacketID >= 0)
             {
-                SocketIOPacket Packet = CreateMessagePacket(JsonArray, PacketID);
+                SocketIOPacket Packet = CreateMessagePacket(JsonArray, PacketID, ns);
 
                 if (Packet.IsJson)
                 {
@@ -55,17 +56,18 @@ namespace SocketIOSharp.Common.Packet
             }
         }
 
-        private static SocketIOPacket CreateMessagePacket(JArray JsonArray, SocketIOAck Ack)
+        private static SocketIOPacket CreateMessagePacket(JArray JsonArray, SocketIOAck Ack, string ns)
         {
-            return CreateMessagePacket(JsonArray, Ack == null ? -1 : Ack.PacketID);
+            return CreateMessagePacket(JsonArray, Ack == null ? -1 : Ack.PacketID, ns);
         }
 
-        private static SocketIOPacket CreateMessagePacket(JArray JsonArray, int PacketID)
+        private static SocketIOPacket CreateMessagePacket(JArray JsonArray, int PacketID, string ns)
         {
             SocketIOPacket Packet = new SocketIOPacket
             {
                 JsonData = JsonArray,
-                IsJson = true
+                IsJson = true,
+                Namespace = ns
             };
 
             if (PacketID >= 0)


### PR DESCRIPTION
Reason:
When you use url like http://localhost:3000/ the socket.io client will create a websocket transport url like ws://localhost:3000/socket.io.
It will work fine.
But when you have url like http://localhost:3000/march, then the websocket transport url is also ws://localhost:3000/socket.io but with namespace "/march".
And onConnection event in client may need connect signal for namespace "/" and also "/march".
After then the emit from server can use namespace "/march" in its packets, and the client will react to namespace "/march" emit.